### PR TITLE
Relocates /enyo/ to /lib/enyo/ for Enyo 2.6.0 and greater.

### DIFF
--- a/common/src/migration.js
+++ b/common/src/migration.js
@@ -1,0 +1,99 @@
+/*
+ * migration.js
+ *
+ * Migrates the enyo framework directory between /enyo and /lib/enyo depending on version.
+ */
+
+var path = require("path"),
+	fs = require("fs"),
+	shell = require("shelljs");
+
+function isLibBased(version, latest) {
+	if(latest) {
+		return true;
+	} else {
+		var minimum = [2,6,0];
+		var keys = version.split(".");
+		for(var i=0; i<keys.length && i<minimum.length; i++) {
+			var tag = keys[i].indexOf("-");
+			if(tag>-1) {
+				keys[i] = keys[i].substring(0, tag);
+			}
+			try {
+				var value = parseInt(keys[i]);
+				if(value>minimum[i]) {
+					return true;
+				} else if(value<minimum[i]) {
+					return false;
+				}
+			} catch(e) {
+				return false;
+			}
+		}
+	}
+	
+	return keys.length>=minimum.length;
+}
+
+function enyoPath(libBased) {
+	return libBased ? "lib/enyo" : "enyo";
+}
+
+function oldPath(enyo) {
+	return enyo==="lib/enyo" ? "enyo" : "lib/enyo";
+}
+
+function updateDeploy(enyo) {
+	if(fs.existsSync("deploy.json")) {
+		var data = fs.readFileSync("deploy.json", {encoding:"utf8"});
+		data = JSON.parse(data);
+		data.enyo = "./" + enyo;
+		data = JSON.stringify(data, null, "\t");
+		fs.writeFileSync("deploy.json", data);
+	}
+}
+
+function updateBower(repo) {
+	if(fs.existsSync("bower.json")) {
+		var data = fs.readFileSync("bower.json", {encoding:"utf8"});
+		data = JSON.parse(data);
+		data.dependencies = data.dependencies || {};
+		if(repo) {
+			data.dependencies.enyo = repo;
+		} else {
+			delete data.dependencies.enyo;
+		}		
+		data = JSON.stringify(data, null, "\t");
+		fs.writeFileSync("bower.json", data);
+	}
+}
+
+function updateHTML(enyo, old) {
+	shell.sed("-i", "\"" + old + "/tools/less.js", "\"" + enyo + "/tools/less.js", "debug.html");
+	shell.sed("-i", "\"" + old + "/enyo.js", "\"" + enyo + "/enyo.js", "debug.html");
+}
+
+function updateScripts(enyo, old) {
+	var bat = path.join("tools", "deploy.bat");
+	shell.sed("-i", "%SRC%\\" + old.replace("/", "\\"), "%SRC%\\" + enyo.replace("/", "\\"), bat);
+	var sh = path.join("tools", "deploy.sh");
+	shell.sed("-i", "$SRC/" + old, "$SRC/" + enyo, sh);
+}
+
+module.exports = {
+	libBased: isLibBased,
+	migrate: function(libBased, repo) {
+		var enyo = enyoPath(libBased);
+		var old = oldPath(enyo);
+		if(!fs.existsSync(enyo) && fs.existsSync(old)) {
+			shell.mv("-f", old, enyo);
+		}
+		if(fs.existsSync(old)) {
+			shell.rm("-fr", old);
+		}
+		updateDeploy(enyo);
+		updateBower((enyo==="lib/enyo" ? repo : undefined));
+		updateHTML(enyo, old);
+		updateScripts(enyo, old)
+	}
+};

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -51,6 +51,10 @@ var EnyoGenerator = yeoman.generators.Base.extend({
 		process.chdir(this.cwd);
 		var valStrOpt = function(arg) {
 			if(arg && typeof arg==="string") {
+				// temporary fix for 3rd party parsing issue
+				if(arg.indexOf("=")===0) {
+					return arg.substring(1);
+				}
 				return arg;
 			} else {
 				return undefined;

--- a/generators/deploy/index.js
+++ b/generators/deploy/index.js
@@ -24,17 +24,20 @@ var EnyoGenerator = yeoman.generators.Base.extend({
 	},
 	
 	_findBootplate: function(dir) {
+		var dir = dir || process.cwd();
 		// 2-level deep search to detect an Enyo bootplate
-		var ENYO_DIR = "enyo";
+		var ENYO_DIR = "lib/enyo";
+		var OLD_ENYO_DIR = "enyo";
 		var result;
-		if(fs.existsSync(path.join(dir, ENYO_DIR))) {
-			result = dir;
+		if(fs.existsSync(path.join(dir, ENYO_DIR)) || fs.existsSync(path.join(dir, OLD_ENYO_DIR))) {
+			result = dir || ".";
 		} else {
 			try {
 				var files = fs.readdirSync(dir);
 				for(var i=0; i<files.length; i++) {
-					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))) {
-						result = path.join(dir, files[i]);
+					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))
+							|| fs.existsSync(path.join(dir, files[i], OLD_ENYO_DIR))) {
+						result = files[i];
 						break;
 					}
 				}

--- a/generators/lib/index.js
+++ b/generators/lib/index.js
@@ -58,6 +58,10 @@ var EnyoGenerator = yeoman.generators.NamedBase.extend({
 
 	_valStrOpt: function(arg) {
 		if(arg && typeof arg==="string") {
+			// temporary fix for 3rd party parsing issue
+			if(arg.indexOf("=")===0) {
+				return arg.substring(1);
+			}
 			return arg;
 		} else {
 			return undefined;
@@ -99,18 +103,20 @@ var EnyoGenerator = yeoman.generators.NamedBase.extend({
 		}
 	},
 
-	_findBootplate: function() {
-		var dir = process.cwd();
+	_findBootplate: function(dir) {
+		var dir = dir || process.cwd();
 		// 2-level deep search to detect an Enyo bootplate
-		var ENYO_DIR = "enyo";
+		var ENYO_DIR = "lib/enyo";
+		var OLD_ENYO_DIR = "enyo";
 		var result;
-		if(fs.existsSync(path.join(dir, ENYO_DIR))) {
-			result = ".";
+		if(fs.existsSync(path.join(dir, ENYO_DIR)) || fs.existsSync(path.join(dir, OLD_ENYO_DIR))) {
+			result = dir || ".";
 		} else {
 			try {
 				var files = fs.readdirSync(dir);
 				for(var i=0; i<files.length; i++) {
-					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))) {
+					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))
+							|| fs.existsSync(path.join(dir, files[i], OLD_ENYO_DIR))) {
 						result = files[i];
 						break;
 					}

--- a/generators/update/index.js
+++ b/generators/update/index.js
@@ -36,6 +36,10 @@ var EnyoGenerator = yeoman.generators.NamedBase.extend({
 		process.chdir(this.cwd);
 		var valStrOpt = function(arg) {
 			if(arg && typeof arg==="string") {
+				// temporary fix for 3rd party parsing issue
+				if(arg.indexOf("=")===0) {
+					return arg.substring(1);
+				}
 				return arg;
 			} else {
 				return undefined;
@@ -56,15 +60,17 @@ var EnyoGenerator = yeoman.generators.NamedBase.extend({
 	_findBootplate: function(dir) {
 		var dir = dir || process.cwd();
 		// 2-level deep search to detect an Enyo bootplate
-		var ENYO_DIR = "enyo";
+		var ENYO_DIR = "lib/enyo";
+		var OLD_ENYO_DIR = "enyo";
 		var result;
-		if(fs.existsSync(path.join(dir, ENYO_DIR))) {
+		if(fs.existsSync(path.join(dir, ENYO_DIR)) || fs.existsSync(path.join(dir, OLD_ENYO_DIR))) {
 			result = dir || ".";
 		} else {
 			try {
 				var files = fs.readdirSync(dir);
 				for(var i=0; i<files.length; i++) {
-					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))) {
+					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))
+							|| fs.existsSync(path.join(dir, files[i], OLD_ENYO_DIR))) {
 						result = files[i];
 						break;
 					}

--- a/generators/webos/index.js
+++ b/generators/webos/index.js
@@ -42,18 +42,20 @@ var EnyoGenerator = yeoman.generators.Base.extend({
 		}
 	},
 	
-	_findBootplate: function() {
-		var dir = process.cwd();
+	_findBootplate: function(dir) {
+		var dir = dir || process.cwd();
 		// 2-level deep search to detect an Enyo bootplate
-		var ENYO_DIR = "enyo";
+		var ENYO_DIR = "lib/enyo";
+		var OLD_ENYO_DIR = "enyo";
 		var result;
-		if(fs.existsSync(path.join(dir, ENYO_DIR))) {
-			result = ".";
+		if(fs.existsSync(path.join(dir, ENYO_DIR)) || fs.existsSync(path.join(dir, OLD_ENYO_DIR))) {
+			result = dir || ".";
 		} else {
 			try {
 				var files = fs.readdirSync(dir);
 				for(var i=0; i<files.length; i++) {
-					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))) {
+					if(fs.existsSync(path.join(dir, files[i], ENYO_DIR))
+							|| fs.existsSync(path.join(dir, files[i], OLD_ENYO_DIR))) {
 						result = files[i];
 						break;
 					}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "webOS"
   ],
   "dependencies": {
-    "shelljs": "~0.3.0",
-    "yeoman-generator": "~0.18.9",
-    "yosay": "~1.0.2",
+    "shelljs": "~0.4.0",
+    "yeoman-generator": "~0.18.10",
+    "yosay": "~1.0.3",
     "chalk": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Migration mechanic to move back and forth between both formats.
Updated dependency versions to current.
Fixed issue with string option parsing.

The enyo relocation will work regardless of the state of the individual repos (so they can be be updated without a time restriction). However http://github.com/enyojs/enyo/pull/1074 is needed for minification to work, so it will be ideal to merge that first, and soon.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
